### PR TITLE
windows compatibility

### DIFF
--- a/lib/newy.js
+++ b/lib/newy.js
@@ -44,7 +44,13 @@ function transversePath(filePath) {
     }
 }
 
+var missingDirCache = {};
+
 function consoleWarn(missingDir) {
+    if (missingDirCache.hasOwnProperty(missingDir)) {
+        return;
+    }
+    missingDirCache[missingDir] = 1;
     console.log("-------------------- Newy Message ------------------" .magenta);
     console.log("Warning - missing directory:" .bold .red);
     console.log(missingDir .bold .red);

--- a/lib/newy.js
+++ b/lib/newy.js
@@ -9,26 +9,39 @@ var PluginError = gutil.PluginError;
 // check for missing directory 
 function checkMissingDir(destinationFile) {
   var filePath = path.dirname(destinationFile);
-  var pathAbsolute = path.isAbsolute(filePath);
-  var directories = filePath.split(path.sep);
-  return transversePath(directories);
+  return transversePath(filePath);
 }
 
-function transversePath(directories) {
-  var pathBuild = '/'; 
-  var directoryMissing = directories.some(function(element) {
-    pathBuild = path.join(pathBuild, element);
-    try {
-      fs.statSync(pathBuild);
-      return false
-    } catch(e) {
-      return true;
+function transversePath(filePath) {
+    var pathBuild = path.normalize(filePath);
+    var error = false;
+    if (!tryStatSync(pathBuild)) {
+        while (true) {
+            error = true;
+            var parentDirPath = path.dirname(pathBuild);
+            if (parentDirPath == pathBuild) {
+                // we are at the top level dir, dirname won't reduce either "C:\\" or "/"
+                break;
+            }
+            if (tryStatSync(parentDirPath)) {
+                break;
+            }
+            pathBuild = parentDirPath;
+        }
     }
-  });
+    if (error) {
+        return pathBuild;
+    } else { return false; }
 
-  if (directoryMissing) {
-    return pathBuild;
-  } else { return false; }
+    function tryStatSync(path) {
+        try {
+            fs.statSync(path);
+            return true;
+        }
+        catch (e) {
+            return false;
+        }
+    }
 }
 
 function consoleWarn(missingDir) {


### PR DESCRIPTION
I was trying to make use of gulp-newy, and it seems to have trouble on Windows. First, my reduced test gulpfile:
```js
var gulp = require('gulp'), plumber = require('gulp-plumber'), newy = require('gulp-newy');

gulp.task('test', function () {
    var step = 0;

    return gulp.src([
            'c:\\windows\\system32\\xcopy.exe', 'c:\\windows\\system32\\cmd.exe', 'c:\\windows\\system32\\powercfg.exe', 'C:\\windows\\notepad.exe',
            '/bin/ls', '/bin/sh', '/bin/true'
        ], {allowEmpty: true})
        .pipe(plumber())
        .pipe(newy(function(projectRoot, srcName, absoluteSrcName) {
            console.log(projectRoot, srcName, absoluteSrcName);
            if (process.platform === 'linux') {
                switch (step++) {
                    case 0: // warning: missing directory /tmp/foo -> OK
                        return '/tmp/foo/bar/test.txt';
                    case 1: // warning: missing directory /tmp/foo -> OK
                        return '//tmp////foo/bar/test.txt';
                    case 2: // (silent)                            -> OK
                        return '/tmp/test.txt';
                }
            } else { // WINDOWS
                switch (step++) {
                    case 0: // warning: missing directory \c\TEMP -> not OK but impossible to fix
                        // this syntax is special for mingw environment and node's statSync will not recognize it as valid,
                        // but users would have to go out of their way to obtain it from projectRoot or absoluteSrcName.
                        return '/c/TEMP/test.txt';
                    case 1: // warning: missing directory \c: -> not OK but at least warning is warranted here, some dirs ARE missing
                        return 'c:\\TEMP\\\\foo\\bar\\test.txt';
                    case 2: // warning: missing directory \c:\TEMP\foo\bar -> same as previous, right output would be that "C:\TEMP\foo" is missing
                        return 'c:///TEMP//foo/bar/test.txt';
                    case 3: // warning: missing directory \c: -> this is *REALLY* not OK, every dir in path does exist
                        return 'C:\\TEMP\\test.txt';
                }
            }
        }));
});
```

All input parameters to the callback function are in the form similar to C:\TEMP\foo\bar, which your test for missing dir can't handle properly. Every missing output file will print warning about "missing directory: \C:", even if the directories are there. I found out about it when I wrote task to pipe about 60 files though imagemin - resulting output looks like it's end of the world, full of red.

I rewrote your test for missing dir from the other end. path.dirname just removes last component of the path, it doesn't care if it is dir or file - so I let it just works backwards from full path until if finds a dir that does exist. This seems to work on both systems.

Second commit just limits the warning to one per each missing directory, I think it makes more sense, but feel free to ignore it.